### PR TITLE
:bug: if no think-js cookie (when first visit), session not set to DB

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,11 @@ class MysqlSession {
     this.expire = 0;
     this.gcType = `session_mysql`;
     gc(this, this.options.gcInterval);
+
+    // flush session when request finish
+    this.ctx.res.once('finish', () => {
+      this.flush();
+    });
   }
 
   [initSessionData]() {
@@ -45,11 +50,6 @@ class MysqlSession {
       this.initPromise = Promise.resolve();
       return this.initPromise;
     }
-
-    // flush session when request finish
-    this.ctx.res.once('finish', () => {
-      this.flush();
-    });
 
     this.initPromise = this.mysql.query({
       sql: `SELECT * FROM ${this.tableName} WHERE cookie = ? `,


### PR DESCRIPTION
之前代码如果浏览器第一次访问thinkjs的服务没有带think-js的cookie的时候，flush()代码永远不会被执行到。

这个bug之所以被发现是因为我用小程序request访问thinkjs服务的时候，一开始是没有带cookie的，发现session数据总是不能写入mysql数据库。

